### PR TITLE
Bubble Chart functionality complete

### DIFF
--- a/public/features/home/primaryArticle.html
+++ b/public/features/home/primaryArticle.html
@@ -12,16 +12,18 @@
       Analyze Tone
     </button>
   </span>
-  <span>
-    <a class="facebook-button" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{primaryArticle.links.permalink}}">
-      <i class="fa fa-facebook-square fa-lg" aria-hidden="true"></i>
-    </a>
-  </span>
-  <span>
-    <a href="https://twitter.com/intent/tweet?text={{primaryArticle.links.permalink}}" data-size="large">
-      <i class="fa fa-twitter-square twitter-share-button" aria-hidden="true"></i>
-    </a>
-  </span>
+  <div class="social-buttons-container">
+    <span>
+      <a class="facebook-button" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{primaryArticle.links.permalink}}">
+        <i class="fa fa-facebook-square fa-lg" aria-hidden="true"></i>
+      </a>
+    </span>
+    <span>
+      <a href="https://twitter.com/intent/tweet?text={{primaryArticle.links.permalink}}" data-size="large">
+        <i class="fa fa-twitter-square twitter-share-button" aria-hidden="true"></i>
+      </a>
+    </span>
+  </div>
 </h2>
 
 <div class="article-subheading">

--- a/public/features/home/primaryArticle.js
+++ b/public/features/home/primaryArticle.js
@@ -36,5 +36,4 @@ angular.module('smartNews.home')
     });
 
   };
-
 });

--- a/public/features/home/trends.html
+++ b/public/features/home/trends.html
@@ -2,7 +2,7 @@
 
   <ul id="trend-list">
     <li class="trend-listing" ng-repeat="trend in trends track by $index">
-      <table ng-click="selectArticle(trend, $event);" class="link">
+      <table class="link">
         <tr>
           <td>
             <div class="trend-rank">{{$index + 1}}</div>
@@ -11,8 +11,7 @@
             <img class="trend-image" ng-src="{{ trend.img }}" alt="trend image">
           </td>
           <td>
-            <div  class="trend-topic">{{trend.topic}}</div>
-            <!-- <div ng-click="selectArticle(trend, $event);"  class="link trend-topic">{{trend.topic}}</div> -->
+            <div ng-click="selectArticle(trend, $event);"  class="link trend-topic">{{trend.topic}}</div>
             <div class="trend-traffic">{{ trend.traffic }} hits</div>
           </td>
         </tr>

--- a/public/features/home/trends.html
+++ b/public/features/home/trends.html
@@ -2,7 +2,7 @@
 
   <ul id="trend-list">
     <li class="trend-listing" ng-repeat="trend in trends track by $index">
-      <table ng-click="selectArticle(trend);" class="link">
+      <table ng-click="selectArticle(trend, $event);" class="link">
         <tr>
           <td>
             <div class="trend-rank">{{$index + 1}}</div>
@@ -12,6 +12,7 @@
           </td>
           <td>
             <div  class="trend-topic">{{trend.topic}}</div>
+            <!-- <div ng-click="selectArticle(trend, $event);"  class="link trend-topic">{{trend.topic}}</div> -->
             <div class="trend-traffic">{{ trend.traffic }} hits</div>
           </td>
         </tr>

--- a/public/features/home/trends.js
+++ b/public/features/home/trends.js
@@ -7,4 +7,34 @@ angular.module('smartNews.home')
       $scope.getPrimaryArticle(topic.articleTitle);
     })(topics[0]);
   });
+// =======
+// .controller('TopTrendsCtrl', function($scope, $http, TopTrendsFactory, Comment, renderWatsonBubbleChart) {
+//   var sanitizeTitle = TopTrendsFactory.sanitizeTitle;
+//   $scope.topTrends = TopTrendsFactory.topTrends;
+
+//   var getSavedComments = function(article) {
+//     Comment.get(article);
+//   };
+
+//   var removeBubbleChart = function(event) {
+//     renderWatsonBubbleChart.removeBubbleChart(event);
+//   }
+
+//   var top = TopTrendsFactory;
+//   $scope.selectArticle = function (topic, $event) {
+
+//     removeBubbleChart($event);
+
+//     var title = sanitizeTitle(topic.articleTitle);
+
+//     TopTrendsFactory.getPrimaryArticle(title)
+//     .then(function (article) {
+//       TopTrendsFactory.primaryArticle[0] = article.data.stories[0];
+
+//       getSavedComments(article.data.stories);
+//     });
+
+//   };
+
+// >>>>>>> Fix homepage bubblechart bugs.  Now bubble chart disappears when you select a new trending article
 });

--- a/public/features/home/trends.js
+++ b/public/features/home/trends.js
@@ -1,9 +1,14 @@
 angular.module('smartNews.home')
 
-.controller('TopTrendsCtrl', function($scope, $http, TopTrendsFactory, Comment) {
+.controller('TopTrendsCtrl', function($scope, $http, TopTrendsFactory, Comment, renderWatsonBubbleChart) {
+  var removeBubbleChart = function(event) {
+    renderWatsonBubbleChart.removeBubbleChart(event);
+  }
+
   TopTrendsFactory.getTrends().then(function(topics) {
     $scope.trends = topics;
-    ($scope.selectArticle = function (topic) { 
+    ($scope.selectArticle = function (topic, $event) {
+      removeBubbleChart($event)      
       $scope.getPrimaryArticle(topic.articleTitle);
     })(topics[0]);
   });

--- a/public/features/results/article.html
+++ b/public/features/results/article.html
@@ -7,21 +7,23 @@
         Save Article
       </button>
     </span>
-    <span class="analyze-button" ng-show="isAuth()">
-      <button ng-click="renderBubbleChart(article, $event)" class="btn btn-default">
-        Analyze Tone
-      </button>
-    </span>
-    <span>
-      <a class="facebook-button" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{article.links.permalink}}">
-        <i class="fa fa-facebook-square fa-lg" aria-hidden="true"></i>
-      </a>
-    </span>
-    <span>
-      <a href="https://twitter.com/intent/tweet?text={{article.links.permalink}}" data-size="large">
-        <i class="fa fa-twitter-square twitter-share-button" aria-hidden="true"></i>
-      </a>
-  </span>
+      <span class="analyze-button" ng-show="isAuth()">
+        <button ng-click="renderBubbleChart(article, $event)" class="btn btn-default">
+          Analyze Tone
+        </button>
+      </span>
+    <div>
+      <span>
+        <a class="facebook-button" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{article.links.permalink}}">
+          <i class="fa fa-facebook-square fa-lg" aria-hidden="true"></i>
+        </a>
+      </span>
+      <span>
+        <a href="https://twitter.com/intent/tweet?text={{article.links.permalink}}" data-size="large">
+          <i class="fa fa-twitter-square twitter-share-button" aria-hidden="true"></i>
+        </a>
+      </span>
+    </div>
   </h2>
 
   <div class="article-subheading">

--- a/public/features/results/article.html
+++ b/public/features/results/article.html
@@ -7,10 +7,10 @@
         Save Article
       </button>
     </span>
-      <span class="analyze-button" ng-show="isAuth()">
-        <button ng-click="renderBubbleChart(article, $event)" class="btn btn-default">
-          Analyze Tone
-        </button>
+    <span class="analyze-button" ng-show="isAuth()">
+      <button ng-click="renderBubbleChart(article, $event)" class="btn btn-default">
+        Analyze Tone
+      </button>
       </span>
     <div>
       <span>

--- a/public/features/results/results.js
+++ b/public/features/results/results.js
@@ -12,8 +12,9 @@ angular.module('smartNews.results', [])
   };
 
   $scope.renderBubbleChart = function(articleData, $event) {
-    console.log('article', articleData);
-    renderWatsonBubbleChart.renderWatsonBubbleChart(articleData, $event)
+    if (renderWatsonBubbleChart.hideBubbleChart($event)) {
+      renderWatsonBubbleChart.renderWatsonBubbleChart(articleData, $event);
+    }
   }
 
   $scope.clickSave = function(el) {

--- a/public/features/results/results.js
+++ b/public/features/results/results.js
@@ -12,6 +12,7 @@ angular.module('smartNews.results', [])
   };
 
   $scope.renderBubbleChart = function(articleData, $event) {
+    console.log('article', articleData);
     renderWatsonBubbleChart.renderWatsonBubbleChart(articleData, $event)
   }
 

--- a/public/layout.html
+++ b/public/layout.html
@@ -24,6 +24,7 @@
   <script src="features/home/home.js"></script>
   <script src="features/home/trends.js"></script>
   <script src="features/home/primaryArticle.js"></script>
+  <script src="features/home/comments.js"></script>
   <script src="features/profile/profile.js"></script>
   <script src="features/home/comments.js"></script>
   <script src="layout.js"></script>

--- a/public/services/services.js
+++ b/public/services/services.js
@@ -40,12 +40,15 @@ angular.module('smartNews.services', ['ngCookies'])
     }
   }
 
+  // set outside of renderWatsonBubbleChart function
+  // so that closure preserves its value with different
+  // instances of the function.
   var svgWidth,
       svgHeight;
 
   var renderWatsonBubbleChart = function(articleData, event) {
-    var button = angular.element(event.target);
     
+    var button = angular.element(event.target);
 
     // If a bubbleChart has already been rendered for that article,
     // don't render another one.
@@ -203,9 +206,24 @@ angular.module('smartNews.services', ['ngCookies'])
     svg.remove();
   }
 
+  var hideBubbleChart = function(event) {
+    var button = angular.element(event.target);
+    if (button.hasClass('inactive')) {
+      button.removeClass('inactive');
+      var svg = event.path[3].children[2];
+      d3.select(svg)
+        .transition()
+          .duration(200)
+          .attr('height', 0);
+      return false;
+    }
+    return true;
+  }
+
   return {
     renderWatsonBubbleChart: renderWatsonBubbleChart,
-    removeBubbleChart: removeBubbleChart
+    removeBubbleChart: removeBubbleChart,
+    hideBubbleChart: hideBubbleChart
   }
 })
 

--- a/public/services/services.js
+++ b/public/services/services.js
@@ -27,19 +27,6 @@ angular.module('smartNews.services', ['ngCookies'])
       });
   };
 
-  var testForExistingSvg = function() {
-    var svgExists = false;
-    var svg;
-    var node = event.path[3].childNodes;
-
-    for (var i = 0; i < node.length; i++) {
-      if (node[i].tagName === 'svg') {
-        svg = node[i];
-        svgExists = true;
-      }
-    }
-  }
-
   // set dimensions outside of renderWatsonBubbleChart function
   // so that closure preserves its value with different
   // instances of the function.
@@ -90,7 +77,7 @@ angular.module('smartNews.services', ['ngCookies'])
 
             var rTotal = 0;
             for (var i = 0; i < data.length; i++) {
-              data[i].r = data[i].score * 100;
+              data[i].r = (data[i].score * 100) + 10;
               rTotal += data[i].r;
             }
 
@@ -122,8 +109,6 @@ angular.module('smartNews.services', ['ngCookies'])
               width: farRight - farLeft,
               height: farBottom - farTop
             }
-
-
 
             // create svg container with slide-down effect
             var svg = d3.select(event.path[3])
@@ -166,7 +151,7 @@ angular.module('smartNews.services', ['ngCookies'])
               sadness: '#086DB2'
             }
             var colorScheme = 0;
-            var bubbleOpacity = .7;
+            var bubbleOpacity = .8;
             var strokeOpacity = 1;
 
 
@@ -174,24 +159,93 @@ angular.module('smartNews.services', ['ngCookies'])
             bubble.attr('cx', (d) => d.x)
               .attr('cy', (d) => d.y - 5)
               .style('fill', (d) => colors[d.tone_id])
-              .style('fill-opacity', bubbleOpacity)
-              .style('stroke', 'white')
-              .style('stroke-width', '1.5px')
-              .style('stroke-opacity', strokeOpacity);
+              .style('fill-opacity', bubbleOpacity);
+
+            d3.selectAll('circle')
+              .classed('small-bubble', (d) => {
+                return d.r < 22;
+              });
+              // .style('stroke', 'white')
+              // .style('stroke-width', '1.5px')
+              // .style('stroke-opacity', strokeOpacity);
 
             // Add text to the bubbles.
             colorIndex = 0;
 
-            nodes.append('text')
+            nodes.filter((d) => d.r >= 21)
+              .append('text')
               .attr('x', (d) => {
                 return d.x;
               })
               .attr('y', (d) => d.y)
               .attr('text-anchor', 'middle')
+              .attr('class', 'bubble-label')
               .text((d) => d.tone_name)
               .style('fill', 'white')
               .style('font-family', '"Karla", regular')
-              .style('font-size', '12px');
+              .style('font-size', '14px')
+              .style('letter-spacing', '0.01em')
+            /*
+            div.transition()        
+              .duration(200)      
+              .style("opacity", .9);      
+            div.html(d.name + "<br/>" + d.r.toFixed(2))  
+              .style("left", (d3.event.pageX) + "px")     
+              .style("top", (d3.event.pageY - 28) + "px");
+            */
+
+            var smallBubbleLabel = d3.select('.bubble-label-svg');
+            var toneId;
+            d3.selectAll('circle')
+              .on('mouseover', function(d) {
+                d3.select(this)
+                  .transition()
+                    .duration(100)
+                    .style('fill-opacity', '1');
+                toneId = d.tone_id;
+                var circle = angular.element(this);
+                if (circle.hasClass('small-bubble')) {
+                  nodes.filter((d) => d.r < 21 && d.tone_id === toneId)
+                    .append('text')
+                    .attr('x', (d) => d.x + d.r)
+                    .attr('y', (d) => d.y - d.r)
+                    .attr('class', 'bubble-label')
+                    .text((d) => d.tone_name)
+                    .style('fill', 'white')
+                    .style('font-family', '"Karla", regular')
+                    .style('font-size', '14px')
+                    .style('letter-spacing', '0.01em')
+                    .style('text-shadow', '0 0 5px black, 0 0 5px black, 0 0 5px black')
+
+                  nodes.filter((d) => d.r < 21 && d.tone_id === toneId)
+                    .append('line')
+                    .attr('x1', d.x)
+                    .attr('y1', d.y - 3)
+                    .attr('x2', d.x + d.r - 1)
+                    .attr('y2', d.y - d.r + 1)
+                    .attr('stroke', 'black')
+                    .attr('stroke-width', '1')
+                }
+              })
+              .on('mouseout', function(d) {
+                d3.select(this)
+                  .transition()
+                    .duration(100)
+                    .style('fill-opacity', bubbleOpacity)
+                // var circle = angular.element(this);
+                // if (circle.hasClass('small-bubble')) {
+                //   nodes.filter((d))
+                // }
+                var lines = d3.selectAll('line')
+                lines.remove();
+
+                var text = d3.selectAll('text')
+                  .filter((d) => d.tone_id === toneId && d.r < 21)
+                  .transition()
+                    .duration(200)
+                    .style('opacity', 0)
+                text.remove();
+              });
           })    
       } 
     }

--- a/public/services/services.js
+++ b/public/services/services.js
@@ -40,16 +40,14 @@ angular.module('smartNews.services', ['ngCookies'])
     }
   }
 
-  // set outside of renderWatsonBubbleChart function
+  // set dimensions outside of renderWatsonBubbleChart function
   // so that closure preserves its value with different
   // instances of the function.
-  var svgWidth,
-      svgHeight;
+  var dimensions = {}
 
   var renderWatsonBubbleChart = function(articleData, event) {
     
     var button = angular.element(event.target);
-
     // If a bubbleChart has already been rendered for that article,
     // don't render another one.
     if (button.hasClass('inactive')) {
@@ -82,7 +80,7 @@ angular.module('smartNews.services', ['ngCookies'])
         d3.select(svg)
           .transition()
             .duration(200)
-            .attr('height', svgHeight)
+            .attr('height', dimensions[articleData.id].height)
       } else {
 
         // Send article text to watson, get tone data back.
@@ -120,8 +118,10 @@ angular.module('smartNews.services', ['ngCookies'])
               var farBottom = bottom > farBottom ? bottom : farBottom;
             }
 
-            svgWidth = farRight - farLeft;
-            svgHeight = farBottom - farTop;
+            dimensions[articleData.id] = {
+              width: farRight - farLeft,
+              height: farBottom - farTop
+            }
 
 
 
@@ -134,8 +134,8 @@ angular.module('smartNews.services', ['ngCookies'])
               .style('margin-bottom', '10px');
             svg.transition()
               .duration(200)
-              .attr('width', svgWidth)
-              .attr('height', svgHeight);
+              .attr('width', dimensions[articleData.id].width)
+              .attr('height', dimensions[articleData.id].height);
 
             // set up the bubble chart
             var nodes = svg.append('g')

--- a/public/services/services.js
+++ b/public/services/services.js
@@ -54,6 +54,7 @@ angular.module('smartNews.services', ['ngCookies'])
 
       var svgExists = false;
       var svg;
+
       var node = event.path[3].childNodes;
 
       //check if a bubble chart already exists for that article.
@@ -77,7 +78,7 @@ angular.module('smartNews.services', ['ngCookies'])
 
             var rTotal = 0;
             for (var i = 0; i < data.length; i++) {
-              data[i].r = (data[i].score * 100) + 10;
+              data[i].r = (data[i].score * 75) + 10;
               rTotal += data[i].r;
             }
 
@@ -255,11 +256,11 @@ angular.module('smartNews.services', ['ngCookies'])
   }
 
   var removeBubbleChart = function(event) {
-    var svg = d3.select('svg')
+    var svg = d3.selectAll('svg')
       .transition()
         .duration(200)
         .attr('height', 0);
-    
+
     d3.select('.inactive')
       .classed('inactive', false);
 

--- a/public/services/services.js
+++ b/public/services/services.js
@@ -106,7 +106,7 @@ angular.module('smartNews.services', ['ngCookies'])
             }
 
             dimensions[articleData.id] = {
-              width: farRight - farLeft + 50,
+              width: farRight - farLeft + 100,
               height: farBottom - farTop + 17
             }
 
@@ -124,7 +124,7 @@ angular.module('smartNews.services', ['ngCookies'])
 
             // set up the bubble chart
             var nodes = svg.append('g')
-              .attr('transform', `translate(${Math.abs(farLeft)}, ${Math.abs(farTop) + 12})`)
+              .attr('transform', `translate(${Math.abs(farLeft) + 50}, ${Math.abs(farTop) + 12})`)
               .selectAll('.bubble')
               .data(circles)
               .enter();

--- a/public/services/services.js
+++ b/public/services/services.js
@@ -182,7 +182,9 @@ angular.module('smartNews.services', ['ngCookies'])
             // Add text to the bubbles.
             colorIndex = 0;
             nodes.append('text')
-              .attr('x', (d) => d.x)
+              .attr('x', (d) => {
+                return d.x;
+              })
               .attr('y', (d) => d.y)
               .attr('text-anchor', 'middle')
               .text((d) => d.tone_name)

--- a/public/services/services.js
+++ b/public/services/services.js
@@ -106,8 +106,8 @@ angular.module('smartNews.services', ['ngCookies'])
             }
 
             dimensions[articleData.id] = {
-              width: farRight - farLeft,
-              height: farBottom - farTop
+              width: farRight - farLeft + 50,
+              height: farBottom - farTop + 17
             }
 
             // create svg container with slide-down effect
@@ -124,7 +124,7 @@ angular.module('smartNews.services', ['ngCookies'])
 
             // set up the bubble chart
             var nodes = svg.append('g')
-              .attr('transform', `translate(${Math.abs(farLeft)}, ${Math.abs(farTop) + 5})`)
+              .attr('transform', `translate(${Math.abs(farLeft)}, ${Math.abs(farTop) + 12})`)
               .selectAll('.bubble')
               .data(circles)
               .enter();
@@ -163,7 +163,7 @@ angular.module('smartNews.services', ['ngCookies'])
 
             d3.selectAll('circle')
               .classed('small-bubble', (d) => {
-                return d.r < 22;
+                return d.r < 25;
               });
               // .style('stroke', 'white')
               // .style('stroke-width', '1.5px')
@@ -172,7 +172,7 @@ angular.module('smartNews.services', ['ngCookies'])
             // Add text to the bubbles.
             colorIndex = 0;
 
-            nodes.filter((d) => d.r >= 21)
+            nodes.filter((d) => d.r >= 25)
               .append('text')
               .attr('x', (d) => {
                 return d.x;
@@ -205,7 +205,10 @@ angular.module('smartNews.services', ['ngCookies'])
                 toneId = d.tone_id;
                 var circle = angular.element(this);
                 if (circle.hasClass('small-bubble')) {
-                  nodes.filter((d) => d.r < 21 && d.tone_id === toneId)
+                  
+                  
+
+                  nodes.filter((d) => d.r < 25 && d.tone_id === toneId)
                     .append('text')
                     .attr('x', (d) => d.x + d.r)
                     .attr('y', (d) => d.y - d.r)
@@ -217,7 +220,7 @@ angular.module('smartNews.services', ['ngCookies'])
                     .style('letter-spacing', '0.01em')
                     .style('text-shadow', '0 0 5px black, 0 0 5px black, 0 0 5px black')
 
-                  nodes.filter((d) => d.r < 21 && d.tone_id === toneId)
+                  nodes.filter((d) => d.r < 25 && d.tone_id === toneId)
                     .append('line')
                     .attr('x1', d.x)
                     .attr('y1', d.y - 3)
@@ -240,7 +243,7 @@ angular.module('smartNews.services', ['ngCookies'])
                 lines.remove();
 
                 var text = d3.selectAll('text')
-                  .filter((d) => d.tone_id === toneId && d.r < 21)
+                  .filter((d) => d.tone_id === toneId && d.r < 25)
                   .transition()
                     .duration(200)
                     .style('opacity', 0)

--- a/public/services/services.js
+++ b/public/services/services.js
@@ -1,13 +1,3 @@
-// TO-DOs
-
-// 1: Make it so timeline width fills out the width of parent div.
-// see: http://jsfiddle.net/shawnbot/BJLe6/
-// use document.getElementById('graph') instead of $('#graph');
-
-// Timeline height can be a fixed px height.
-
-// 2: Set up graph to start from the middle of y-axes rather than bottom
-
 angular.module('smartNews.services', ['ngCookies'])
 
 .factory('renderWatsonBubbleChart', function($rootScope, $http) {
@@ -166,10 +156,7 @@ angular.module('smartNews.services', ['ngCookies'])
               .classed('small-bubble', (d) => {
                 return d.r < 25;
               });
-              // .style('stroke', 'white')
-              // .style('stroke-width', '1.5px')
-              // .style('stroke-opacity', strokeOpacity);
-
+              
             // Add text to the bubbles.
             colorIndex = 0;
 
@@ -186,14 +173,6 @@ angular.module('smartNews.services', ['ngCookies'])
               .style('font-family', '"Karla", regular')
               .style('font-size', '14px')
               .style('letter-spacing', '0.01em')
-            /*
-            div.transition()        
-              .duration(200)      
-              .style("opacity", .9);      
-            div.html(d.name + "<br/>" + d.r.toFixed(2))  
-              .style("left", (d3.event.pageX) + "px")     
-              .style("top", (d3.event.pageY - 28) + "px");
-            */
 
             var smallBubbleLabel = d3.select('.bubble-label-svg');
             var toneId;
@@ -236,10 +215,7 @@ angular.module('smartNews.services', ['ngCookies'])
                   .transition()
                     .duration(100)
                     .style('fill-opacity', bubbleOpacity)
-                // var circle = angular.element(this);
-                // if (circle.hasClass('small-bubble')) {
-                //   nodes.filter((d))
-                // }
+
                 var lines = d3.selectAll('line')
                 lines.remove();
 
@@ -326,8 +302,6 @@ angular.module('smartNews.services', ['ngCookies'])
       // .classed('svg-container', true) //container class to make it responsive
       .append('svg')
       // responsive SVG needs these two attr's and an absence of height and width attr's
-      // .attr('preserveAspectRatio', 'xMinYMin meet') // preserves aspect ratio by 'fitting' the viewbox to the viewport, rather than filling
-      // .attr('viewBox', '0 0 ' + (window.innerWidth) + ' ' + (window.innerHeight))
       .attr('viewBox', '0 0 ' + (window.innerWidth) + ' ' + 400 )
       // append group element
       .append('g')

--- a/public/services/services.js
+++ b/public/services/services.js
@@ -162,7 +162,7 @@ angular.module('smartNews.services', ['ngCookies'])
               anger: '#E80521',
               disgust: '#592684',
               fear: '#325E2B',
-              joy: '#FFD629',
+              joy: '#FF8C23',
               sadness: '#086DB2'
             }
             var colorScheme = 0;
@@ -181,6 +181,7 @@ angular.module('smartNews.services', ['ngCookies'])
 
             // Add text to the bubbles.
             colorIndex = 0;
+
             nodes.append('text')
               .attr('x', (d) => {
                 return d.x;

--- a/public/services/services.js
+++ b/public/services/services.js
@@ -44,7 +44,6 @@ angular.module('smartNews.services', ['ngCookies'])
       svgHeight;
 
   var renderWatsonBubbleChart = function(articleData, event) {
-
     var button = angular.element(event.target);
     
 
@@ -101,7 +100,6 @@ angular.module('smartNews.services', ['ngCookies'])
             var circles = d3.packSiblings(data);
 
             // determine the dimensions of the bubble chart
-            console.log(circles);
             var farLeft = circles[0].x - circles[0].r;
             var farTop = circles[0].y - circles[0].r;
             var farRight = circles[0].x + circles[0].r;
@@ -193,8 +191,21 @@ angular.module('smartNews.services', ['ngCookies'])
     }
   }
 
+  var removeBubbleChart = function(event) {
+    var svg = d3.select('svg')
+      .transition()
+        .duration(200)
+        .attr('height', 0);
+    
+    d3.select('.inactive')
+      .classed('inactive', false);
+
+    svg.remove();
+  }
+
   return {
-    renderWatsonBubbleChart: renderWatsonBubbleChart
+    renderWatsonBubbleChart: renderWatsonBubbleChart,
+    removeBubbleChart: removeBubbleChart
   }
 })
 

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -226,6 +226,7 @@ li.trend-listing {
 }
 
 .article-subheading {
+  margin-top: 20px;
   font-family: 'EB Garamond', serif;
   font-size: 16px;
   padding: 10px 10px 12px 0px;
@@ -480,19 +481,22 @@ div.tooltip-articles {
   display: flex;
   align-items: center;
   justify-content: space-around;
-  font-family: helvetica, arial, sans-serif;
+  float: left;
   background: #4267b2;
   border-radius: 4px;
+  margin-top: 2px;
+  margin-bottom: 2px;
+  margin-right: 2px;
   font-size: 13px;
-  height: 27px;
-  width: 27px;
+  height: 25.7px;
+  width: 25.7px;
   color: #fff;
   cursor: pointer;
 }
 
 .facebook-button:hover {
   background: #365899;
-  border: 1px solid #365899;
+  /*border: 1px solid #365899;*/
   color: white;
   text-decoration: none;
 }
@@ -501,6 +505,7 @@ div.tooltip-articles {
   color: #1da1f2;
   height: 27px;
   width: 27px;
+  float: left;
 }
 
 .twitter-share-button:hover {

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -226,7 +226,7 @@ li.trend-listing {
 }
 
 .article-subheading {
-  margin-top: 20px;
+  margin-top: 23px;
   font-family: 'EB Garamond', serif;
   font-size: 16px;
   padding: 10px 10px 12px 0px;
@@ -486,7 +486,7 @@ div.tooltip-articles {
   border-radius: 4px;
   margin-top: 2px;
   margin-bottom: 2px;
-  margin-right: 2px;
+  margin-right: 4px;
   font-size: 13px;
   height: 25.7px;
   width: 25.7px;
@@ -510,4 +510,8 @@ div.tooltip-articles {
 
 .twitter-share-button:hover {
   color: #0c7abf
+}
+
+.social-buttons-container {
+  margin: 2px 0;
 }


### PR DESCRIPTION
- SVG component now expands to the exact size of the bubble chart, so the bubbles are no longer cropped
- Clicking a 'trend' on the homescreen now removes the svg so that a new one can be rendered for the new article.
- Once an svg is loaded for an article, a second get-request to the watson api is not necessary to load it a second time. (after refresh, however, it does require a new get request)
- General bug fixes and improvements on how it renders in the window.
- Style of bubble chart revamped and improved.
